### PR TITLE
Agora o script de instalação tem opção pra escolher entre compilar estaticamente ou dinamicamente

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,9 +21,9 @@ fi
 ## ter em sua raís, o prefixo dessa configuração será alguma pasata no
 ## diretório local ($3).
 function vendorize_local_library {
-	local LIB_NAME="${1}"     #1: string
-	local LIB_VERSION="${2}"  #2: string
-	local VENDOR_DIR="${3}"   #3: string
+	local LIB_NAME="${1}"     #$1: string - Nome da pasta da lib local
+	local LIB_VERSION="${2}"  #$2: string - Versao da lib, arbitrário
+	local VENDOR_DIR="${3}"   #$3: string - Nome da pasta de vendor local
 
 	printf "\033[36m[LOGG]\033[m "
 	echo "Configurando a biblioteca ${LIB_NAME}"

--- a/install.sh
+++ b/install.sh
@@ -15,21 +15,22 @@ else
 	exit 1
 fi
 
-# TODO: Ver se é realmente necessário rodar o make
+function vendorize_local_library {
+	local LIB_NAME="${1}"
+	local LIB_VERSION="${2}"
+	local VENDOR_DIR="${3}"
 
-echo "Configurando as bibliotecas locais"
+	printf "\033[36m[LOGG]\033[m "
+	echo "Configurando a biblioteca ${LIB_NAME}"
 
-mkdir -p vendor/{libao_1.2.2,mpg123_1.26.4}
+	local TARGET_PATH="${VENDOR_DIR}/${LIB_NAME}_${LIB_VERSION}"
 
-cd libao
-./configure --prefix=$(pwd)/../vendor/libao_1.2.2
-# make
-cd ..
+	mkdir -vp "${TARGET_PATH}"
+	bash -c "cd ${LIB_NAME} && ./configure --prefix=\$(pwd)/../${TARGET_PATH}"
+}
 
-cd mpg123
-./configure --prefix=$(pwd)/../vendor/mpg123_1.26.4
-# make
-cd ..
+vendorize_local_library "libao"  "1.2.2"  "vendor"
+vendorize_local_library "mpg123" "1.26.4" "vendor"
 
 echo "Compilando com $COMPILER..."
 

--- a/install.sh
+++ b/install.sh
@@ -9,8 +9,10 @@ then
 	COMPILER=$(which clang)
 
 else
+	echo
 	printf "\033[31m[ERRO]\033[m "
-	printf "Os compiladores 'clang' e 'gcc' não foram encontrados\n"
+	echo "Os compiladores 'clang' e 'gcc' não foram encontrados"
+	echo
 
 	exit 1
 fi
@@ -36,13 +38,17 @@ vendorize_local_library "libao"  "1.2.2"  "vendor"
 vendorize_local_library "mpg123" "1.26.4" "vendor"
 
 function compile_statically {
+	echo
 	printf "\033[33m[WARN]\033[m "
 	echo "Esse script não consegue compilar estaticamente ainda!"
+	echo
 }
 
 function compile_shared {
+	echo
 	printf "\033[36m[LOGG]\033[m "
 	echo "Compilando a aplicação com as bibliotecas do sistema"
+	echo
 
 	eval "${COMPILER} playmp3.c main.c \
 		-lao -lavcodec -lavformat -lswresample -lavutil \

--- a/install.sh
+++ b/install.sh
@@ -35,10 +35,20 @@ function vendorize_local_library {
 vendorize_local_library "libao"  "1.2.2"  "vendor"
 vendorize_local_library "mpg123" "1.26.4" "vendor"
 
-echo "Compilando com $COMPILER..."
+function compile_statically {
+	printf "\033[33m[WARN]\033[m "
+	echo "Esse script não consegue compilar estaticamente ainda!"
+}
 
-$COMPILER clang playmp3.c main.c \
-	-Wl,-Bstatic \
-	-I./vendor/libao_1.2.2/include -L./vendor/libao_1.2.2/.libs -lao \
-	-lavcodec -lavformat -lswresample -lavutil \
-	-o playmp3
+function compile_shared {
+	printf "\033[36m[LOGG]\033[m "
+	echo "Compilando a aplicação com as bibliotecas do sistema"
+
+	eval "${COMPILER} playmp3.c main.c \
+		-lao -lavcodec -lavformat -lswresample -lavutil \
+		-o playmp3"
+}
+
+[ "${1}" = "--static" ] || [ "${1}" = "-s" ] &&
+	compile_statically ||
+	compile_shared

--- a/install.sh
+++ b/install.sh
@@ -34,6 +34,9 @@ function vendorize_local_library {
 	bash -c "cd ${LIB_NAME} && ./configure --prefix=\$(pwd)/../${TARGET_PATH}"
 }
 
+#TODO: Seria melhor se a pasta `/vendor` tivese a sua própria variável
+#TODO: Essa variável poderia ser alterada com uma opção `--vendor`
+#TODO: O usuário deve ter a opção de skippar essa parte se ele quiser
 vendorize_local_library "libao"  "1.2.2"  "vendor"
 vendorize_local_library "mpg123" "1.26.4" "vendor"
 
@@ -50,11 +53,18 @@ function compile_shared {
 	echo "Compilando a aplicação com as bibliotecas do sistema"
 	echo
 
+	#TODO: Colocar os arquivos de source em constantes também
+	#TODO: Colocar as flagas de bibliotecas em uma constante
+	#TODO: Deixar o usuário usar flags customizadas se ele quiser
+	#TODO: Por o nome do binário final em uma variável
+	#TODO: O path  do binário pode ser customizado pelo usuário também
 	eval "${COMPILER} playmp3.c main.c \
 		-lao -lavcodec -lavformat -lswresample -lavutil \
 		-o playmp3"
 }
 
+#TODO: A função de compilar estaticamente não deve funcionar com `--skip-conf`
+#TODO: Criar a opção `--static` do jeito certo
 [ "${1}" = "--static" ] || [ "${1}" = "-s" ] &&
 	compile_statically ||
 	compile_shared

--- a/install.sh
+++ b/install.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
 
-# Verifica se clang está disponível
-if command -v clang &>/dev/null; then
-	COMPILER="clang"
-# Caso contrário, verifica se gcc está disponível
-elif command -v gcc &>/dev/null; then
-	COMPILER="gcc"
+if clang -v &> /dev/null
+then
+	COMPILER=$(which clang)
+
+elif gcc -v &> /dev/null
+then
+	COMPILER=$(which clang)
+
 else
-	echo "Nenhum compilador (clang ou gcc) encontrado no sistema."
+	printf "\033[31m[ERRO]\033[m "
+	printf "Os compiladores 'clang' e 'gcc' não foram encontrados\n"
+
 	exit 1
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -34,19 +34,8 @@ vendorize_local_library "mpg123" "1.26.4" "vendor"
 
 echo "Compilando com $COMPILER..."
 
-# TODO: Incluir as bibliotecas da mpg123 localmente também
-# TODO: Fazer o processo de compilação linkar as bibliotecas estaticamente
-
 $COMPILER clang playmp3.c main.c \
 	-Wl,-Bstatic \
 	-I./vendor/libao_1.2.2/include -L./vendor/libao_1.2.2/.libs -lao \
 	-lavcodec -lavformat -lswresample -lavutil \
 	-o playmp3
-
-#$COMPILER -o playaudio main.c playmp3.c -Ilibao/include -Llibao/lib -Wl,-Bstatic -lao -Wl,-Bdynamic -lavformat -lavcodec -lswresample -lavutil -lm -lpthread -lz -lssl -lcrypto
-if [ $? -eq 0 ]; then
-	echo "Compilação concluída com sucesso!"
-else
-	echo "Erro durante a compilação."
-	exit 1
-fi

--- a/install.sh
+++ b/install.sh
@@ -15,10 +15,13 @@ else
 	exit 1
 fi
 
+## Essa função vai rodar o script `./configure` que a biblioteca (`$1`) deve
+## ter em sua raís, o prefixo dessa configuração será alguma pasata no
+## diretório local ($3).
 function vendorize_local_library {
-	local LIB_NAME="${1}"
-	local LIB_VERSION="${2}"
-	local VENDOR_DIR="${3}"
+	local LIB_NAME="${1}"     #1: string
+	local LIB_VERSION="${2}"  #2: string
+	local VENDOR_DIR="${3}"   #3: string
 
 	printf "\033[36m[LOGG]\033[m "
 	echo "Configurando a biblioteca ${LIB_NAME}"


### PR DESCRIPTION
Agora o `install.sh` compila dinamicamente por padrão, mas aceita a opção `--static`, ou `-s`, pra compilar estaticamente, mas essa função não foi implementada ainda.

Tomei liberdade pra dar uma refatorada no script pra ele seguir algumas convenções que a maioria dos dev adotam pro script ficar mais legível (no caso de bash, isso é importante).

O único probleminha é que essa opção de `--static` está *hard coded* com um `if..else` no final do arquivo, o ideal seria se o script tivesse um *parser* de argumentos. Mas eu deixei isso anotado no próprio código com alguns comentários `#TODO:`, pode deixar que esses detalhes de usabilidade do script eu cuido depois.

No mais, acredito que isso já seja o bastante pra poder testar o programa nesse estágio de desenvolvimento ainda.